### PR TITLE
Make width of open_layers_zoom_map fluid

### DIFF
--- a/views/shared/css/OpenLayersZoom.css
+++ b/views/shared/css/OpenLayersZoom.css
@@ -1,5 +1,5 @@
 #open_layers_zoom_map {
-    width: 712px;
+    width: 100%;
     height: 456px;
     border: 1px solid #ccc;
     clear: both;


### PR DESCRIPTION
The fixed width of the open_layers_zoom_map element at https://github.com/Daniel-KM/OpenLayersZoom/blob/master/views/shared/css/OpenLayersZoom.css#L2 causes the page to fail Google's new Mobile Usability guidelines. Replacing it with a fluid width satisfies Google. Tested on Omeka 2.3 default theme e.g. https://www.wallandbinkley.com/rcb/omeka/items/show/60
